### PR TITLE
Cleanup/forward http errors

### DIFF
--- a/source/extensions/filters/http/grpc_http1_reverse_bridge_transcoder/filter.h
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge_transcoder/filter.h
@@ -34,6 +34,10 @@ private:
   template <class CallbackType>
   void respondWithGrpcError(CallbackType& callback_type, const std::string_view description);
 
+  template <class CallbackType>
+  void respondWithGrpcError(CallbackType& callback_type, const std::string_view description,
+                            Grpc::Status::GrpcStatus grpc_status);
+
 private:
   Transcoder transcoder_;
   bool enabled_;


### PR DESCRIPTION
This PR add functionality to examine the HTTP Status Codes in received Responses. In case of an error, further processing is stopped and a gRPC message containing the mapped status code is sent downstream.